### PR TITLE
/works/ から /#works にリダイレクトさせる

### DIFF
--- a/layouts/works/list.html
+++ b/layouts/works/list.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script>
+        location.replace('{{ relref . "/#works" }}');
+    </script>
+    <title>Redirect</title>
+</head>
+
+</html>


### PR DESCRIPTION
<https://nishi-yuki.github.io/works/>にアクセスするとrssのxmlファイルが見えてしまっていた。
対策として、`/#works`にリダイレクトさせることにした